### PR TITLE
Add User in Express Requests data

### DIFF
--- a/backend/src/@types/express.d.ts
+++ b/backend/src/@types/express.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Overriding the Express Request including User
+ * id is required and name is optional
+ */
+
+declare namespace Express {
+  export interface Request {
+    user: {
+      id: string
+      name?: string
+    }
+  }
+}

--- a/backend/src/config/auth.ts
+++ b/backend/src/config/auth.ts
@@ -1,0 +1,8 @@
+export default {
+
+  jwt: {
+    secret: 'comparecomprameucocoporquequempoucocococomprapoucocococome',
+    expiresIn: '1d'
+  }
+
+}

--- a/backend/src/middlewares/ensureAuthenticated.ts
+++ b/backend/src/middlewares/ensureAuthenticated.ts
@@ -1,0 +1,27 @@
+import { Request, Response, NextFunction } from 'express'
+import { verify } from 'jsonwebtoken'
+
+import authConfig from '../config/auth'
+
+export default function ensureAuthenticated(
+  request: Request, response: Response,next: NextFunction
+): void {
+
+  const authHeader = request.headers.authorization
+
+  if (!authHeader) {
+    throw new Error('JWT token is missing')
+  }
+
+  const [, token] = authHeader.split(' ')
+
+  try {
+    const decoded = verify(token, authConfig.jwt.secret)
+
+    console.log(decoded)
+
+    return next()
+  } catch {
+    throw new Error('Invalid JWT token')
+  }
+}

--- a/backend/src/routes/appointments.routes.ts
+++ b/backend/src/routes/appointments.routes.ts
@@ -4,8 +4,11 @@ import { getCustomRepository } from 'typeorm'
 
 import AppointmentsRepository from '../repositories/AppointmentsRepository'
 import CreateAppointmentService from '../services/CreateAppointmentService'
+import ensureAuthenticated from '../middlewares/ensureAuthenticated'
 
 const appointmentsRouter = Router()
+
+appointmentsRouter.use(ensureAuthenticated)
 
 appointmentsRouter.get('/', async (request, response) => {
   const appointmentsRepository = getCustomRepository(AppointmentsRepository)

--- a/backend/src/services/AuthenticateUserService.ts
+++ b/backend/src/services/AuthenticateUserService.ts
@@ -4,6 +4,7 @@ import { sign } from 'jsonwebtoken'
 
 import User from '../models/User'
 import usersTransformer, { TransformedUser } from '../transformers/users.transformer'
+import authConfig from '../config/auth'
 
 interface RequestDTO {
   email: string
@@ -34,9 +35,11 @@ export default class AuthenticateUserService {
       throw new Error(errorMessage)
     }
 
-    const token = sign({}, 'secret', {
+    const { secret, expiresIn } = authConfig.jwt
+
+    const token = sign({}, secret, {
       subject: user.id,
-      expiresIn: '1d'
+      expiresIn
     })
 
     return {


### PR DESCRIPTION
No arquivo @types/express.d.ts estamos sobrescrevendo a tipagem do Express, incluindo o objeto User que tem um id e name,
name não é obrigatório

declare namespace Express {
  export interface Request {
    user: {
      id: string
      name?: string
    }
  }
}

No middleware ensureAuthenticated:
const [, token] = authHeader.split(' ')  // paga o token após o espaço por q mandamos do front "Bearer xxxxxx"

const { sub: id } = verify(token, authConfig.jwt.secret) as TokenPayload  // sub é o id do user no token, então tranformo ele em id para usar short syntax ao inserir o user no request logo em seguida 