### PR TITLE
Rewriting appointments repository

### DIFF
--- a/backend/src/modules/appointments/dtos/ICreateAppointmentDTO.ts
+++ b/backend/src/modules/appointments/dtos/ICreateAppointmentDTO.ts
@@ -1,0 +1,5 @@
+
+export default interface ICreateAppointmentDTO {
+  provider_id: string
+  date: Date
+}

--- a/backend/src/modules/appointments/infra/repositories/IAppointmentsRepository.ts
+++ b/backend/src/modules/appointments/infra/repositories/IAppointmentsRepository.ts
@@ -1,7 +1,9 @@
 import Appointment from '@/modules/appointments/infra/typeorm/entities/Appointment'
+import ICreateAppointmentDTO from '@/modules/appointments/dtos/ICreateAppointmentDTO'
 
 export default interface IAppointmentRepository {
 
+  create(data: ICreateAppointmentDTO): Promise<Appointment>
   findByDate(date: Date): Promise<Appointment | undefined>
 
 }

--- a/backend/src/modules/appointments/infra/typeorm/entities/Appointment.ts
+++ b/backend/src/modules/appointments/infra/typeorm/entities/Appointment.ts
@@ -3,11 +3,6 @@ import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm'
 import Defaults from '@/shared/entities/Defaults'
 import User from '@/modules/users/infra/typeorm/entities/User'
 
-export interface CreateAppointmentDTO {
-  provider_id: string
-  date: Date
-}
-
 @Entity('appointments')
 export default class Appointment extends Defaults {
 

--- a/backend/src/modules/appointments/infra/typeorm/repositories/AppointmentsRepository.ts
+++ b/backend/src/modules/appointments/infra/typeorm/repositories/AppointmentsRepository.ts
@@ -1,15 +1,31 @@
-import { EntityRepository, Repository } from 'typeorm'
+import { getRepository, Repository } from 'typeorm'
 
 import Appointment from '@/modules/appointments/infra/typeorm/entities/Appointment'
 import IAppointmentRepository from '@/modules/appointments/infra/repositories/IAppointmentsRepository'
+import ICreateAppointmentDTO from '@/modules/appointments/dtos/ICreateAppointmentDTO'
 
-@EntityRepository(Appointment)
-export default class AppointmentsRepository
-  extends Repository<Appointment> implements IAppointmentRepository {
+export default class AppointmentsRepository implements IAppointmentRepository {
+
+  private ormRepository: Repository<Appointment>
+
+  constructor() {
+    this.ormRepository = getRepository(Appointment)
+  }
 
   public async findByDate(date: Date): Promise<Appointment | undefined> {
-    const findAppointment = await this.findOne({ where: { date } })
+    const findAppointment = await this.ormRepository.findOne({
+      where: { date }
+    })
     return findAppointment
+  }
+
+
+  public async create({ provider_id, date}: ICreateAppointmentDTO): Promise<Appointment> {
+    const appointment = this.ormRepository.create({ provider_id, date })
+
+    await this.ormRepository.save(appointment)
+
+    return appointment
   }
 
 }

--- a/backend/src/modules/appointments/services/CreateAppointmentService.ts
+++ b/backend/src/modules/appointments/services/CreateAppointmentService.ts
@@ -1,13 +1,14 @@
 import { startOfHour } from 'date-fns'
 import { getCustomRepository } from 'typeorm'
 
-import Appointment, { CreateAppointmentDTO } from '@/modules/appointments/infra/typeorm/entities/Appointment'
+import Appointment from '@/modules/appointments/infra/typeorm/entities/Appointment'
 import AppointmentsRepository from '@/modules/appointments/infra/typeorm/repositories/AppointmentsRepository'
+import ICreateAppointmentDTO from '@/modules/appointments/dtos/ICreateAppointmentDTO'
 import AppError from '@/shared/errors/AppError'
 
 export default class CreateAppointmentService {
 
-  public async execute({ provider_id, date }: CreateAppointmentDTO): Promise<Appointment> {
+  public async execute({ provider_id, date }: ICreateAppointmentDTO): Promise<Appointment> {
     const appointmentsRepository = getCustomRepository(AppointmentsRepository)
 
     const appointmentDate = startOfHour(date)
@@ -18,12 +19,10 @@ export default class CreateAppointmentService {
       throw new AppError('This appointment is already booked')
     }
 
-    const appointment = appointmentsRepository.create({
+    const appointment = await appointmentsRepository.create({
       provider_id,
       date: appointmentDate
     })
-
-    await appointmentsRepository.save(appointment)
 
     return appointment
   }


### PR DESCRIPTION
Reescrever os métodos dos repositórios para que tenhamos mais controle sobre eles, como por exemplo, quais parâmetros recebe e qual o tipo de retorno.

Isso foi feito baseado na interface do repositório e não no repositório em si. Isso torna o código mais flexível.