### PR TITLE
Create user test & base.css dark style for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ annotationsFrontend.md
 annotationsMobile.md
 
 backend/tmp/*
-!backend/tmp/.gitkeep
+!backend/tmp/base.css

--- a/README.md
+++ b/README.md
@@ -64,3 +64,6 @@
 - Os agendamentos devem estar disponíveis entre 8h e 18h (primeiro às 8h, último as 17h)
 - O usuário não pode agendar em um horário já reservado
 - O usuário não pode agendar em um serviço consigo mesmo
+
+O arquivo tmp/base.css é uma dark style para os Jest coverage reports, basta substituir no path
+node_modules/istanbul-reports/lib/html/assets/base.css

--- a/backend/src/modules/users/repositories/fakes/FakeUsersRepository.ts
+++ b/backend/src/modules/users/repositories/fakes/FakeUsersRepository.ts
@@ -1,0 +1,46 @@
+import { generate } from 'shortid'
+
+import IUserRepository from '@/modules/users/repositories/IUsersRepository'
+import ICreateUsertDTO from '@/modules/users/dtos/ICreateUserDTO'
+
+import User from '@/modules/users/infra/typeorm/entities/User'
+
+export default class UsersRepository implements IUserRepository {
+
+  private users: User[] = []
+
+  public async findById(id: string): Promise<User | undefined> {
+    const findUser = this.users.find(user => user.id === id)
+
+    return findUser
+  }
+
+
+  public async findByEmail(email: string): Promise<User | undefined> {
+    const findUser = this.users.find(user => user.email === email)
+
+    return findUser
+  }
+
+
+  public async create({ name, email, password }: ICreateUsertDTO): Promise<User> {
+    const user = new User()
+
+    Object.assign(user, { id: generate(), name, email, password })
+
+    this.users.push(user)
+
+    return user
+  }
+
+
+  public async save(user: User): Promise<User> {
+    const userIndex = this.users.findIndex(findUser => findUser.id === user.id)
+
+    this.users[userIndex] = user
+
+    return user
+  }
+
+}
+

--- a/backend/src/modules/users/services/CreateUserService.spec.ts
+++ b/backend/src/modules/users/services/CreateUserService.spec.ts
@@ -1,0 +1,42 @@
+
+import AppError from '@/shared/errors/AppError'
+import FakeUsersRepository from '@/modules/users/repositories/fakes/FakeUsersRepository.ts'
+import CreateUserService from './CreateUserService'
+
+
+describe('CreateUser', () => {
+
+  it('should be able to create a new user', async () => {
+    const fakeUsersRepository = new FakeUsersRepository()
+    const createUserService = new CreateUserService(fakeUsersRepository)
+
+    const user = await createUserService.execute({
+      name: 'Jardel Bordignon',
+      email: 'jardel@email.com',
+      password: '123456'
+    })
+
+    expect(user).toHaveProperty('id')
+  })
+
+
+  it('should not be able to create a new user with an email already registered ', async () => {
+    const fakeUsersRepository = new FakeUsersRepository()
+    const createUserService = new CreateUserService(fakeUsersRepository)
+
+    await createUserService.execute({
+      name: 'Jardel Bordignon',
+      email: 'jardel@email.com',
+      password: '123456'
+    })
+
+    expect(
+      createUserService.execute({
+        name: 'Jardel Bordignon',
+        email: 'jardel@email.com',
+        password: '123456'
+      })
+    ).rejects.toBeInstanceOf(AppError)
+  })
+
+})

--- a/backend/tmp/base.css
+++ b/backend/tmp/base.css
@@ -1,0 +1,372 @@
+body,
+html {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+}
+body {
+  font-family: Helvetica Neue, Helvetica, Arial;
+  font-size: 16px;
+  color: #ddd;
+}
+
+/*  */
+pre {
+  font-size: 14px !important;
+}
+pre.prettyprint span.kwd {
+  color: #ff79c6;
+}
+pre.prettyprint span.pln {
+  color: #999;
+}
+pre.prettyprint span.typ {
+  color: #ccc;
+}
+pre.prettyprint span.str {
+  color: #67e480;
+}
+
+.small {
+  font-size: 12px;
+}
+*,
+*:after,
+*:before {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+h1 {
+  font-size: 20px;
+  margin: 0;
+}
+h2 {
+  font-size: 14px;
+}
+pre {
+  font: 12px/1.4 Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+  margin: 0;
+  padding: 0;
+  -moz-tab-size: 2;
+  -o-tab-size: 2;
+  tab-size: 2;
+}
+a {
+  color: #0074d9;
+  text-decoration: none;
+}
+a:hover {
+  text-decoration: underline;
+}
+.strong {
+  font-weight: bold;
+}
+.space-top1 {
+  padding: 10px 0 0 0;
+}
+.pad2y {
+  padding: 20px 0;
+}
+.pad1y {
+  padding: 10px 0;
+}
+.pad2x {
+  padding: 0 20px;
+}
+.pad2 {
+  padding: 20px;
+}
+.pad1 {
+  padding: 10px;
+}
+.space-left2 {
+  padding-left: 55px;
+}
+.space-right2 {
+  padding-right: 20px;
+}
+.center {
+  text-align: center;
+}
+.clearfix {
+  display: block;
+}
+.clearfix:after {
+  content: '';
+  display: block;
+  height: 0;
+  clear: both;
+  visibility: hidden;
+}
+.fl {
+  float: left;
+}
+@media only screen and (max-width: 640px) {
+  .col3 {
+    width: 100%;
+    max-width: 100%;
+  }
+  .hide-mobile {
+    display: none !important;
+  }
+}
+
+.quiet {
+  color: #ccc;
+}
+.quiet a {
+  opacity: 0.7;
+}
+
+.fraction {
+  font-family: Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+  font-size: 10px;
+  color: #e8e8e8;
+  border: 1px solid #e8e8e8;
+  padding: 4px 5px;
+  border-radius: 3px;
+  vertical-align: middle;
+}
+
+div.path a:link,
+div.path a:visited {
+  color: #333;
+}
+table.coverage {
+  border-collapse: collapse;
+  margin: 10px 0 0 0;
+  padding: 0;
+}
+
+table.coverage td {
+  margin: 0;
+  padding: 0;
+  vertical-align: top;
+}
+table.coverage td.line-count {
+  text-align: right;
+  padding: 0 5px 0 20px;
+}
+table.coverage td.line-coverage {
+  text-align: right;
+  padding-right: 10px;
+  min-width: 20px;
+}
+
+table.coverage td span.cline-any {
+  display: inline-block;
+  padding: 0 5px;
+  width: 100%;
+}
+.missing-if-branch {
+  display: inline-block;
+  margin-right: 5px;
+  border-radius: 3px;
+  position: relative;
+  padding: 0 4px;
+  background: #333;
+  color: yellow;
+}
+
+.skip-if-branch {
+  display: none;
+  margin-right: 10px;
+  position: relative;
+  padding: 0 4px;
+  background: #ccc;
+  color: white;
+}
+.missing-if-branch .typ,
+.skip-if-branch .typ {
+  color: inherit !important;
+}
+.coverage-summary {
+  border-collapse: collapse;
+  width: 100%;
+}
+.coverage-summary tr {
+  border-bottom: 1px solid #bbb;
+}
+.keyline-all {
+  border: 1px solid #ddd;
+}
+.coverage-summary td,
+.coverage-summary th {
+  padding: 10px;
+}
+.coverage-summary tbody {
+  border: 1px solid #bbb;
+}
+.coverage-summary td {
+  border-right: 1px solid #bbb;
+}
+.coverage-summary td:last-child {
+  border-right: none;
+}
+.coverage-summary th {
+  text-align: left;
+  font-weight: normal;
+  white-space: nowrap;
+}
+.coverage-summary th.file {
+  border-right: none !important;
+}
+.coverage-summary th.pct {
+}
+.coverage-summary th.pic,
+.coverage-summary th.abs,
+.coverage-summary td.pct,
+.coverage-summary td.abs {
+  text-align: right;
+}
+.coverage-summary td.file {
+  white-space: nowrap;
+}
+.coverage-summary td.pic {
+  min-width: 120px !important;
+}
+.coverage-summary tfoot td {
+}
+
+.coverage-summary .sorter {
+  height: 10px;
+  width: 7px;
+  display: inline-block;
+  margin-left: 0.5em;
+  background: url(sort-arrow-sprite.png) no-repeat scroll 0 0 transparent;
+}
+.coverage-summary .sorted .sorter {
+  background-position: 0 -20px;
+}
+.coverage-summary .sorted-desc .sorter {
+  background-position: 0 -10px;
+}
+.status-line {
+  height: 1px;
+}
+/* yellow */
+.cbranch-no {
+  background: yellow !important;
+  color: #111;
+}
+/* dark red */
+.red.solid,
+.status-line.low,
+.low .cover-fill {
+  background: #c21f39;
+}
+.low .chart {
+  border: 1px solid #c21f39;
+}
+.highlighted,
+.highlighted .cstat-no,
+.highlighted .fstat-no,
+.highlighted .cbranch-no {
+  background: #c21f39 !important;
+}
+/* medium red */
+.cstat-no,
+.fstat-no,
+.cbranch-no,
+.cbranch-no {
+  background: #f6c6ce;
+}
+/* light red */
+.low,
+.cline-no {
+  background: #111;
+}
+/* light green */
+.high,
+.cline-yes {
+  background: #333;
+}
+/* medium green */
+.cstat-yes {
+  background: rgb(161, 215, 106);
+}
+/* dark green */
+.status-line.high,
+.high .cover-fill {
+  background: rgb(77, 146, 33);
+}
+.high .chart {
+  border: 1px solid rgb(77, 146, 33);
+}
+/* dark yellow (gold) */
+.status-line.medium,
+.medium .cover-fill {
+  background: #f9cd0b;
+}
+.medium .chart {
+  border: 1px solid #f9cd0b;
+}
+/* light yellow */
+.medium {
+  background: #666;
+}
+
+.cstat-skip {
+  background: #ddd;
+  color: #111;
+}
+.fstat-skip {
+  background: #ddd;
+  color: #111 !important;
+}
+.cbranch-skip {
+  background: #ddd !important;
+  color: #111;
+}
+
+span.cline-neutral {
+  background: transparent;
+}
+
+.coverage-summary td.empty {
+  opacity: 0.5;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  line-height: 1;
+  color: #888;
+}
+
+.cover-fill,
+.cover-empty {
+  display: inline-block;
+  height: 12px;
+}
+.chart {
+  line-height: 0;
+}
+.cover-empty {
+  background: transparent;
+}
+.cover-full {
+  border-right: none !important;
+}
+pre.prettyprint {
+  border: none !important;
+  padding: 0 !important;
+  margin: 0 !important;
+}
+.com {
+  color: #999 !important;
+}
+.ignore-none {
+  color: #999;
+  font-weight: normal;
+}
+
+.wrapper {
+  min-height: 100%;
+  height: auto !important;
+  height: 100%;
+  margin: 0 auto -48px;
+  background: #000;
+}
+.footer,
+.push {
+  height: 48px;
+}


### PR DESCRIPTION
Testando criação de usuário
- Deve ser possível criar um usuário
- Não deve ser possível criar um usuário usando um e-mail já registrado

Alterei o arquivo de estilo da apresentação dos testes para um tema escuro, o base.css encontra-se do diretório tmp do projeto, no node_modules ele fica em node_modules/istanbul-reports/lib/html/assets/base.css, basta substituí-los.