### PR TITLE
Authentication test

### DIFF
--- a/backend/src/modules/users/providers/HashProvider/fakes/FakeHashProvider.ts
+++ b/backend/src/modules/users/providers/HashProvider/fakes/FakeHashProvider.ts
@@ -1,0 +1,14 @@
+
+import IHashProvider from '../models/IHashProvider';
+
+export default class BCryptHashProvider implements IHashProvider {
+
+  public async generateHash(password: string): Promise<string> {
+    return password
+  }
+
+  public async compareHash(password: string, hashedPassword: string): Promise<boolean> {
+    return password === hashedPassword
+  }
+
+}

--- a/backend/src/modules/users/providers/HashProvider/implementations/BCryptHashProvider.ts
+++ b/backend/src/modules/users/providers/HashProvider/implementations/BCryptHashProvider.ts
@@ -1,0 +1,15 @@
+import { hash, compare } from 'bcryptjs'
+
+import IHashProvider from '../models/IHashProvider';
+
+export default class BCryptHashProvider implements IHashProvider {
+
+  public async generateHash(password: string): Promise<string> {
+    return hash(password, 8)
+  }
+
+  public async compareHash(password: string, hashedPassword: string): Promise<boolean> {
+    return compare(password, hashedPassword)
+  }
+
+}

--- a/backend/src/modules/users/providers/HashProvider/models/IHashProvider.ts
+++ b/backend/src/modules/users/providers/HashProvider/models/IHashProvider.ts
@@ -1,0 +1,7 @@
+
+export default interface IHashProvider {
+
+  generateHash(password: string): Promise<string>
+  compareHash(password: string, hashedPassword: string): Promise<boolean>
+
+}

--- a/backend/src/modules/users/providers/index.ts
+++ b/backend/src/modules/users/providers/index.ts
@@ -1,0 +1,8 @@
+import { container as dependencyInjector } from 'tsyringe'
+
+import IHashProvider from '@/modules/users/providers/HashProvider/models/IHashProvider'
+import BCryptHashProvider from '@/modules/users/providers/HashProvider/implementations/BCryptHashProvider'
+
+dependencyInjector.registerSingleton<IHashProvider>(
+  'HashProvider', BCryptHashProvider
+)

--- a/backend/src/modules/users/services/AuthenticateUserService.spec.ts
+++ b/backend/src/modules/users/services/AuthenticateUserService.spec.ts
@@ -1,0 +1,37 @@
+import AppError from '@/shared/errors/AppError'
+
+import FakeUsersRepository from '@/modules/users/repositories/fakes/FakeUsersRepository'
+import FakeHashProvider from '@/modules/users/providers/HashProvider/fakes/FakeHashProvider'
+import AuthenticateUserService from './AuthenticateUserService'
+import CreateUserService from './CreateUserService'
+
+describe('AuthenticateUser', () => {
+
+  it('should be able to authenticate', async () => {
+    const fakeUsersRepository = new FakeUsersRepository()
+    const fakeHashProvider = new FakeHashProvider()
+
+    const createUserService = new CreateUserService(
+      fakeUsersRepository, fakeHashProvider
+    )
+
+    const authenticateUserService = new AuthenticateUserService(
+      fakeUsersRepository, fakeHashProvider
+    )
+
+    const user = await createUserService.execute({
+      name: 'Jardel Bordignon',
+      email: 'jardel@email.com',
+      password: '123456'
+    })
+
+    const response = await authenticateUserService.execute({
+      email: 'jardel@email.com',
+      password: '123456'
+    })
+
+    expect(response).toHaveProperty('token')
+    expect(response.user.id).toEqual(user.id)
+  })
+
+})

--- a/backend/src/modules/users/services/CreateUserService.spec.ts
+++ b/backend/src/modules/users/services/CreateUserService.spec.ts
@@ -2,13 +2,15 @@
 import AppError from '@/shared/errors/AppError'
 import FakeUsersRepository from '@/modules/users/repositories/fakes/FakeUsersRepository.ts'
 import CreateUserService from './CreateUserService'
+import FakeHashProvider from '../providers/HashProvider/fakes/FakeHashProvider'
 
 
 describe('CreateUser', () => {
 
   it('should be able to create a new user', async () => {
     const fakeUsersRepository = new FakeUsersRepository()
-    const createUserService = new CreateUserService(fakeUsersRepository)
+    const fakeHashProvider = new FakeHashProvider()
+    const createUserService = new CreateUserService(fakeUsersRepository, fakeHashProvider)
 
     const user = await createUserService.execute({
       name: 'Jardel Bordignon',
@@ -22,7 +24,8 @@ describe('CreateUser', () => {
 
   it('should not be able to create a new user with an email already registered ', async () => {
     const fakeUsersRepository = new FakeUsersRepository()
-    const createUserService = new CreateUserService(fakeUsersRepository)
+    const fakeHashProvider = new FakeHashProvider()
+    const createUserService = new CreateUserService(fakeUsersRepository, fakeHashProvider)
 
     await createUserService.execute({
       name: 'Jardel Bordignon',

--- a/backend/src/modules/users/services/CreateUserService.ts
+++ b/backend/src/modules/users/services/CreateUserService.ts
@@ -1,17 +1,20 @@
-import { hash } from 'bcryptjs'
 import { injectable, inject } from 'tsyringe'
 
-import ICreateUserDTO from '@/modules/users/dtos/ICreateUserDTO'
-import User from '@/modules/users/infra/typeorm/entities/User'
 import AppError from '@/shared/errors/AppError'
-import IUsersRepository from '../repositories/IUsersRepository'
+import ICreateUserDTO from '@/modules/users/dtos/ICreateUserDTO'
+import IUsersRepository from '@/modules/users/repositories/IUsersRepository'
+import IHashProvider from '@/modules/users/providers/HashProvider/models/IHashProvider'
+import User from '@/modules/users/infra/typeorm/entities/User'
 
 @injectable()
 export default class CreateUserService {
 
   constructor(
     @inject('UsersRepository')
-    private usersRepository: IUsersRepository
+    private usersRepository: IUsersRepository,
+
+    @inject('HashProvider')
+    private hashProvider: IHashProvider
   ) {}
 
   public async execute({ name, email, password }: ICreateUserDTO): Promise<User> {
@@ -22,7 +25,7 @@ export default class CreateUserService {
       throw new AppError('Email address already used.')
     }
 
-    const hashPassword = await hash(password, 8)
+    const hashPassword = await this.hashProvider.generateHash(password)
 
     const user = await this.usersRepository.create({
       name, email, password: hashPassword

--- a/backend/src/shared/dependencyInjector/index.ts
+++ b/backend/src/shared/dependencyInjector/index.ts
@@ -1,5 +1,7 @@
 import { container as dependencyInjector } from 'tsyringe'
 
+import '@/modules/users/providers'
+
 import IAppointmentsRepository from '@/modules/appointments/repositories/IAppointmentsRepository'
 import AppointmentsRepository from '@/modules/appointments/infra/typeorm/repositories/AppointmentsRepository'
 

--- a/backend/tmp/base.css
+++ b/backend/tmp/base.css
@@ -263,14 +263,16 @@ table.coverage td span.cline-any {
 .highlighted .cstat-no,
 .highlighted .fstat-no,
 .highlighted .cbranch-no {
-  background: #c21f39 !important;
+  border: 1px solid #c21f39 !important;
 }
 /* medium red */
 .cstat-no,
 .fstat-no,
 .cbranch-no,
 .cbranch-no {
-  background: #f6c6ce;
+  border: 1px solid #c21f39 !important;
+  padding: 1px 20px 1px 0;
+  background: transparent;
 }
 /* light red */
 .low,


### PR DESCRIPTION
- Necessário usar o CreateUserService para criar um usuário antes de testar se é possível efetuar o login.
  É esperado que o retorno contenha um token
- Como CreateUserService tem a função de criar um usuário (Single Responsability Principle), a função de criar um hash da senha _await hash(password, 8)_ foi isolada para modules/users/providers/HashProvider, além de que dessa forma HashProvider pode ser usado em outras partes da aplicação também.