### PR TITLE
Atualizacao de avatar

### DIFF
--- a/backend/src/config/upload.ts
+++ b/backend/src/config/upload.ts
@@ -2,11 +2,14 @@ import path from 'path'
 import crypto from 'crypto'
 import multer from 'multer'
 
-export const tmpDirectory = path.resolve(__dirname, '..', '..', 'tmp')
+export const tmpFolder = path.resolve(__dirname, '..', '..', 'tmp')
 
 export default {
+  tmpFolder,
+  uploadsFolder: path.resolve(tmpFolder, 'uploads'),
+
 	storage: multer.diskStorage({
-		destination: tmpDirectory,
+		destination: tmpFolder,
 		filename(request, file, callback) {
 			const fileHash = crypto.randomBytes(10).toString('hex')
 			const fileName = `${fileHash}-${file.originalname}`

--- a/backend/src/modules/users/services/UpdateUserAvatarService.spec.ts
+++ b/backend/src/modules/users/services/UpdateUserAvatarService.spec.ts
@@ -1,0 +1,81 @@
+
+import AppError from '@/shared/errors/AppError'
+
+import FakeStorageProvider from '@/shared/providers/StorageProvider/fakes/FakeStorageProvider'
+import FakeUsersRepository from '../repositories/fakes/FakeUsersRepository'
+import UpdateUserAvatarService from './UpdateUserAvatarService'
+
+
+describe('UpdateUserAvatar', () => {
+
+  it('should be able to update user avatar', async () => {
+    const fakeUsersRepository = new FakeUsersRepository()
+    const fakeStorageProvider = new FakeStorageProvider()
+
+    const updateUserAvatarService = new UpdateUserAvatarService(
+      fakeUsersRepository, fakeStorageProvider
+    )
+
+    const user = await fakeUsersRepository.create({
+      name: 'Jardel Bordignon',
+      email: 'jardel@email.com',
+      password: '123456'
+    })
+
+    await updateUserAvatarService.execute({
+      user_id: user.id,
+      avatarFilename: 'avatar.jpg'
+    })
+
+    expect(user.avatar).toBe('avatar.jpg')
+  })
+
+
+  it('should not be able to update user avatar from non existing user', async () => {
+    const fakeUsersRepository = new FakeUsersRepository()
+    const fakeStorageProvider = new FakeStorageProvider()
+
+    const updateUserAvatarService = new UpdateUserAvatarService(
+      fakeUsersRepository, fakeStorageProvider
+    )
+
+    expect(
+      updateUserAvatarService.execute({
+        user_id: 'non-existing-user',
+        avatarFilename: 'avatar.jpg'
+      })
+    ).rejects.toBeInstanceOf(AppError)
+  })
+
+
+  it('should delete old avatar when updating new one', async () => {
+    const fakeUsersRepository = new FakeUsersRepository()
+    const fakeStorageProvider = new FakeStorageProvider()
+
+    const updateUserAvatarService = new UpdateUserAvatarService(
+      fakeUsersRepository, fakeStorageProvider
+    )
+
+    const deleteFile = jest.spyOn(fakeStorageProvider, 'deleteFile')
+
+    const user = await fakeUsersRepository.create({
+      name: 'Jardel Bordignon',
+      email: 'jardel@email.com',
+      password: '123456'
+    })
+
+    await updateUserAvatarService.execute({
+      user_id: user.id,
+      avatarFilename: 'avatar.jpg'
+    })
+
+    await updateUserAvatarService.execute({
+      user_id: user.id,
+      avatarFilename: 'avatar2.jpg'
+    })
+
+    expect(deleteFile).toHaveBeenCalledWith('avatar.jpg')
+    expect(user.avatar).toBe('avatar2.jpg')
+  })
+
+})

--- a/backend/src/shared/DependencyInjectionContainer.ts
+++ b/backend/src/shared/DependencyInjectionContainer.ts
@@ -1,5 +1,6 @@
 import { container as dependencyInjector } from 'tsyringe'
 
+import '@/shared/providers'
 import '@/modules/users/providers'
 
 import IAppointmentsRepository from '@/modules/appointments/repositories/IAppointmentsRepository'

--- a/backend/src/shared/infra/http/server.ts
+++ b/backend/src/shared/infra/http/server.ts
@@ -2,18 +2,18 @@ import 'reflect-metadata'
 import express, { Request, Response, NextFunction } from 'express'
 import 'express-async-errors'
 
-import { tmpDirectory } from '@/config/upload'
+import uploadConfig from '@/config/upload'
 import AppError from '@/shared/errors/AppError'
 import routes from '@/shared/infra/http/routes'
 
 import '@/shared/infra/typeorm' // database
-import '@/shared/dependencyInjector' // dependency injection
+import '../../DependencyInjectionContainer'
 
 const app = express()
 
 app.use(express.json())
 
-app.use('/files', express.static(tmpDirectory))
+app.use('/files', express.static(uploadConfig.uploadsFolder))
 
 app.use(routes)
 

--- a/backend/src/shared/providers/StorageProvider/fakes/FakeStorageProvider.ts
+++ b/backend/src/shared/providers/StorageProvider/fakes/FakeStorageProvider.ts
@@ -1,0 +1,19 @@
+import IStorageProvider from '../models/IStorageProvider'
+
+export default class FakeStorageProvider implements IStorageProvider{
+
+  private storage: string[] = []
+
+  public async saveFile(file: string): Promise<string> {
+    this.storage.push(file)
+
+    return file
+  }
+
+  public async deleteFile(file: string): Promise<void> {
+    const findIndex = this.storage.findIndex(storageFile => storageFile === file)
+
+    this.storage.splice(findIndex, 1)
+  }
+
+}

--- a/backend/src/shared/providers/StorageProvider/implementations/DiskStorageProvider.ts
+++ b/backend/src/shared/providers/StorageProvider/implementations/DiskStorageProvider.ts
@@ -1,0 +1,26 @@
+import fs from 'fs'
+import path from 'path'
+
+import uploadConfig from '@/config/upload'
+import IStorageProvider from '../models/IStorageProvider'
+
+export default class DiskStorageProvider implements IStorageProvider{
+
+  public async saveFile(file: string): Promise<string> {
+    await fs.promises.rename(
+      path.resolve(uploadConfig.tmpFolder, file),
+      path.resolve(uploadConfig.uploadsFolder, file)
+    )
+
+    return file
+  }
+
+  public async deleteFile(file: string): Promise<void> {
+    const filePath = path.resolve(uploadConfig.tmpFolder, file)
+
+    if (!fs.existsSync(filePath)) return
+
+    await fs.promises.unlink(filePath)
+  }
+
+}

--- a/backend/src/shared/providers/StorageProvider/models/IStorageProvider.ts
+++ b/backend/src/shared/providers/StorageProvider/models/IStorageProvider.ts
@@ -1,0 +1,6 @@
+export default interface IStorageProvider {
+
+  saveFile(file: string): Promise<string>
+  deleteFile(file: string): Promise<void>
+
+}

--- a/backend/src/shared/providers/index.ts
+++ b/backend/src/shared/providers/index.ts
@@ -1,0 +1,8 @@
+import { container as dependencyInjector } from 'tsyringe'
+
+import IStorageProvider from './StorageProvider/models/IStorageProvider'
+import DiskStorageProvider from './StorageProvider/implementations/DiskStorageProvider'
+
+dependencyInjector.registerSingleton<IStorageProvider> (
+  'StorageProvider', DiskStorageProvider
+)


### PR DESCRIPTION
Testes Atualização do Avatar
- Deve ser possível criar um avatar
- Não deve ser possível atualizar o avatar de um usuário que não exista
- Deve deletar o avatar antigo quando for alterado

Para o último teste foi usado jest.spyOn pra observar se a função deleteFile do fakeStorageProvider é executada no processo