### PR TITLE
Password recovery

### DIFF
--- a/backend/src/modules/appointments/services/CreateAppointmentService.spec.ts
+++ b/backend/src/modules/appointments/services/CreateAppointmentService.spec.ts
@@ -28,7 +28,7 @@ describe('CreateAppointment', () => {
       date: appointmentDate
     })
 
-    expect(
+    await expect(
       createAppointmentService.execute({
         provider_id: '123abc',
         date: appointmentDate

--- a/backend/src/modules/users/services/AuthenticateUserService.spec.ts
+++ b/backend/src/modules/users/services/AuthenticateUserService.spec.ts
@@ -43,7 +43,7 @@ describe('AuthenticateUser', () => {
       fakeUsersRepository, fakeHashProvider
     )
 
-    expect(
+    await expect(
       authenticateUserService.execute({
         email: 'jardel@email.com',
         password: '123456'
@@ -70,7 +70,7 @@ describe('AuthenticateUser', () => {
       password: '123456'
     })
 
-    expect(
+    await expect(
       authenticateUserService.execute({
         email: 'jardel@email.com',
         password: 'wrong-password'

--- a/backend/src/modules/users/services/CreateUserService.spec.ts
+++ b/backend/src/modules/users/services/CreateUserService.spec.ts
@@ -33,7 +33,7 @@ describe('CreateUser', () => {
       password: '123456'
     })
 
-    expect(
+    await expect(
       createUserService.execute({
         name: 'Jardel Bordignon',
         email: 'jardel@email.com',

--- a/backend/src/modules/users/services/SendForgotPasswordEmailService.spec.ts
+++ b/backend/src/modules/users/services/SendForgotPasswordEmailService.spec.ts
@@ -1,0 +1,46 @@
+import AppError from '@/shared/errors/AppError'
+
+import FakeUsersRepository from '@/modules/users/repositories/fakes/FakeUsersRepository.ts'
+import FakeMailProvider from '@/shared/providers/MailProvider/fakes/FakeMailProvider'
+import SendForgotPasswordEmailService from './SendForgotPasswordEmailService'
+
+describe('SendForgotPasswordEmailService', () => {
+
+  it('should be able to recover the password using the email', async () => {
+    const fakeUsersRepository = new FakeUsersRepository()
+    const fakeMailProvider = new FakeMailProvider()
+    const sendForgotPasswordEmailService = new SendForgotPasswordEmailService(
+      fakeUsersRepository, fakeMailProvider
+    )
+
+    const sendEmail = jest.spyOn(fakeMailProvider, 'sendEmail')
+
+    await fakeUsersRepository.create({
+      name: 'Jardel Bordignon',
+      email: 'jardel@email.com',
+      password: '1234546'
+    })
+
+    await sendForgotPasswordEmailService.execute({
+      email: 'jardel@email.com'
+    })
+
+    expect(sendEmail).toHaveBeenCalled()
+  })
+
+
+  it('should be able to recover the password using the non-existing user email', async () => {
+    const fakeUsersRepository = new FakeUsersRepository()
+    const fakeMailProvider = new FakeMailProvider()
+    const sendForgotPasswordEmailService = new SendForgotPasswordEmailService(
+      fakeUsersRepository, fakeMailProvider
+    )
+
+    await expect(
+      sendForgotPasswordEmailService.execute({
+        email: 'jardel@email.com'
+      })
+    ).rejects.toBeInstanceOf(AppError)
+  })
+
+})

--- a/backend/src/modules/users/services/SendForgotPasswordEmailService.ts
+++ b/backend/src/modules/users/services/SendForgotPasswordEmailService.ts
@@ -1,0 +1,35 @@
+import { injectable, inject } from 'tsyringe'
+
+//import AppError from '@/shared/errors/AppError'
+import IUsersRepository from '@/modules/users/repositories/IUsersRepository'
+import IMailProvider from '@/shared/providers/MailProvider/models/IMailProvider'
+import AppError from '@/shared/errors/AppError'
+//import User from '@/modules/users/infra/typeorm/entities/User'
+
+interface IRequest {
+  email: string
+}
+
+@injectable()
+export default class SendForgotPasswordEmailService {
+
+  constructor(
+    @inject('UsersRepository')
+    private usersRepository: IUsersRepository,
+
+    @inject('MailProvider')
+    private mailProvider: IMailProvider
+  ) {}
+
+
+  public async execute({ email }: IRequest): Promise<void> {
+    const checkUserExists = await this.usersRepository.findByEmail(email)
+
+    if (!checkUserExists) {
+      throw new AppError('User does not exists')
+    }
+
+    this.mailProvider.sendEmail(email, 'Recuperação de senha')
+  }
+
+}

--- a/backend/src/modules/users/services/UpdateUserAvatarService.spec.ts
+++ b/backend/src/modules/users/services/UpdateUserAvatarService.spec.ts
@@ -39,7 +39,7 @@ describe('UpdateUserAvatar', () => {
       fakeUsersRepository, fakeStorageProvider
     )
 
-    expect(
+    await expect(
       updateUserAvatarService.execute({
         user_id: 'non-existing-user',
         avatarFilename: 'avatar.jpg'

--- a/backend/src/shared/providers/MailProvider/fakes/FakeMailProvider.ts
+++ b/backend/src/shared/providers/MailProvider/fakes/FakeMailProvider.ts
@@ -1,0 +1,16 @@
+import IMailProvider from '@/shared/providers/MailProvider/models/IMailProvider'
+
+interface IMessage {
+  to: string
+  body: string
+}
+
+export default class FakeMailProvider implements IMailProvider {
+
+  private messages: IMessage[] = []
+
+  public async sendEmail(to: string, body: string): Promise<void> {
+    this.messages.push({ to, body })
+  }
+
+}

--- a/backend/src/shared/providers/MailProvider/models/IMailProvider.ts
+++ b/backend/src/shared/providers/MailProvider/models/IMailProvider.ts
@@ -1,0 +1,5 @@
+export default interface IMailProvider {
+
+  sendEmail(to: string, body: string): Promise<void>
+
+}


### PR DESCRIPTION
criado teste SendForgotPasswordEmailService,
para testar o envio de e-mail da recuperação de senha o provider
shared/providers/MailProvider, dentro dele o FakeMailProvider simula o envio de e-mail.

- Deve ser possível recuperar a senha usando e-mail
- Não deve ser possível recuperar a senha de um usuário que não exista