### PR TITLE
Email Template Engine

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -15,6 +15,7 @@
     "date-fns": "^2.16.1",
     "express": "^4.17.1",
     "express-async-errors": "^3.1.1",
+    "handlebars": "^4.7.6",
     "jsonwebtoken": "^8.5.1",
     "multer": "^1.4.2",
     "mysql": "^2.18.1",
@@ -26,6 +27,7 @@
   "devDependencies": {
     "@types/bcryptjs": "^2.4.2",
     "@types/express": "^4.17.11",
+    "@types/handlebars": "^4.1.0",
     "@types/jest": "^26.0.20",
     "@types/jsonwebtoken": "^8.5.0",
     "@types/multer": "^1.4.5",

--- a/backend/src/modules/users/services/SendForgotPasswordEmailService.spec.ts
+++ b/backend/src/modules/users/services/SendForgotPasswordEmailService.spec.ts
@@ -23,7 +23,7 @@ describe('SendForgotPasswordEmailService', () => {
   })
 
   it('should be able to recover the password using the email', async () => {
-    const sendEmail = jest.spyOn(fakeMailProvider, 'sendEmail')
+    const sendEmail = jest.spyOn(fakeMailProvider, 'sendMail')
 
     await fakeUsersRepository.create({
       name: 'Jardel Bordignon',

--- a/backend/src/modules/users/services/SendForgotPasswordEmailService.ts
+++ b/backend/src/modules/users/services/SendForgotPasswordEmailService.ts
@@ -36,7 +36,20 @@ export default class SendForgotPasswordEmailService {
 
     const { token } = await this.userTokensRepository.generate(user.id)
 
-    await this.mailProvider.sendMail(email, `Recuperação de senha: ${token}`)
+    await this.mailProvider.sendMail({
+      to: {
+        name: user.name,
+        email: user.email
+      },
+      subject: '[GoBarber] Recuperação de senha',
+      templateData: {
+        variables: {
+          name: user.name,
+          token
+        },
+        template: 'Olá, {{name}}: {{token}}'
+      }
+    })
   }
 
 }

--- a/backend/src/shared/providers/MailProvider/dtos/ISendMailDTO.ts
+++ b/backend/src/shared/providers/MailProvider/dtos/ISendMailDTO.ts
@@ -1,0 +1,13 @@
+import IParseTemplateDTO from '../../MailTemplateProvider/dtos/IParseTemplateDTO'
+
+interface IMailContact {
+  name: string
+  email: string
+}
+
+export default interface ISendMailDTO {
+  to: IMailContact
+  from?: IMailContact
+  subject: string
+  templateData: IParseTemplateDTO
+}

--- a/backend/src/shared/providers/MailProvider/fakes/FakeMailProvider.ts
+++ b/backend/src/shared/providers/MailProvider/fakes/FakeMailProvider.ts
@@ -1,16 +1,12 @@
-import IMailProvider from '@/shared/providers/MailProvider/models/IMailProvider'
-
-interface IMessage {
-  to: string
-  body: string
-}
+import IMailProvider from '../models/IMailProvider'
+import ISendMailDTO from '../dtos/ISendMailDTO'
 
 export default class FakeMailProvider implements IMailProvider {
 
-  private messages: IMessage[] = []
+  private messages: ISendMailDTO[] = []
 
-  public async sendEmail(to: string, body: string): Promise<void> {
-    this.messages.push({ to, body })
+  public async sendMail(message: ISendMailDTO): Promise<void> {
+    this.messages.push(message)
   }
 
 }

--- a/backend/src/shared/providers/MailProvider/implementations/EtherealMailProvider.ts
+++ b/backend/src/shared/providers/MailProvider/implementations/EtherealMailProvider.ts
@@ -1,12 +1,20 @@
 import nodemailer, { Transporter } from 'nodemailer'
+import { injectable, inject } from 'tsyringe'
 
-import IMailProvider from '@/shared/providers/MailProvider/models/IMailProvider'
+import { DI_MAIL_TEMPLATE_PROVIDER } from '@/shared/providers'
+import IMailTemplateProvider from '@/shared/providers/MailTemplateProvider/models/IMailTemplateProvider'
+import IMailProvider from '../models/IMailProvider'
+import ISendMailDTO from '../dtos/ISendMailDTO'
 
+@injectable()
 export default class EtherealMailProvider implements IMailProvider {
 
   private client: Transporter
 
-  constructor() {
+  constructor(
+    @inject(DI_MAIL_TEMPLATE_PROVIDER)
+    private mailTemplateProvider: IMailTemplateProvider
+  ) {
     nodemailer.createTestAccount().then(account => {
       const transporter = nodemailer.createTransport({
         host: account.smtp.host,
@@ -23,16 +31,21 @@ export default class EtherealMailProvider implements IMailProvider {
 
       this.client = transporter
     })
-
   }
 
 
-  public async sendMail(to: string, body: string): Promise<void> {
+  public async sendMail({ to, from, subject, templateData }: ISendMailDTO): Promise<void> {
     const message = await this.client.sendMail({
-      from: 'Equipe GoBarber <equipe@gobarber.com.br>',
-      to,
-      subject: 'Recuperação de senha',
-      text: body
+      from:{
+        name: from?.name || 'Equipe GoBarber',
+        address: from?.email || 'equipe@gobarber.com.br'
+      },
+      to: {
+        name: to.name,
+        address: to.email
+      },
+      subject,
+      html: await this.mailTemplateProvider.parse(templateData)
     })
 
     console.log('Message sent: %s', message.messageId)

--- a/backend/src/shared/providers/MailProvider/models/IMailProvider.ts
+++ b/backend/src/shared/providers/MailProvider/models/IMailProvider.ts
@@ -1,5 +1,5 @@
+import ISendMailDTO from '../dtos/ISendMailDTO'
+
 export default interface IMailProvider {
-
-  sendMail(to: string, body: string): Promise<void>
-
+  sendMail(data: ISendMailDTO): Promise<void>
 }

--- a/backend/src/shared/providers/MailTemplateProvider/dtos/IParseTemplateDTO.ts
+++ b/backend/src/shared/providers/MailTemplateProvider/dtos/IParseTemplateDTO.ts
@@ -1,0 +1,8 @@
+interface ITemplateVariables {
+  [key: string]: string | number
+}
+
+export default interface IParseTemplateDTO {
+  template: string
+  variables: ITemplateVariables
+}

--- a/backend/src/shared/providers/MailTemplateProvider/fakes/FakeMailTemplateProvider.ts
+++ b/backend/src/shared/providers/MailTemplateProvider/fakes/FakeMailTemplateProvider.ts
@@ -1,0 +1,10 @@
+import IParseTemplateDTO from '../dtos/IParseTemplateDTO';
+import IMailTemplateProvider from '../models/IMailTemplateProvider';
+
+export default class FakeMailTemplateProvider implements IMailTemplateProvider {
+
+  public async parse({ template }: IParseTemplateDTO): Promise<string> {
+    return template
+  }
+
+}

--- a/backend/src/shared/providers/MailTemplateProvider/implementations/HandlebarsMailTemplateProvider.ts
+++ b/backend/src/shared/providers/MailTemplateProvider/implementations/HandlebarsMailTemplateProvider.ts
@@ -1,0 +1,14 @@
+import handlebars from 'handlebars'
+
+import IParseTemplateDTO from '../dtos/IParseTemplateDTO';
+import IMailTemplateProvider from '../models/IMailTemplateProvider';
+
+export default class HandlebarsMailTemplateProvider implements IMailTemplateProvider {
+
+  public async parse({ template, variables }: IParseTemplateDTO): Promise<string> {
+    const parseTemplate = handlebars.compile(template)
+
+    return parseTemplate(variables)
+  }
+
+}

--- a/backend/src/shared/providers/MailTemplateProvider/models/IMailTemplateProvider.ts
+++ b/backend/src/shared/providers/MailTemplateProvider/models/IMailTemplateProvider.ts
@@ -1,0 +1,7 @@
+import IParseTemplateDTO from '../dtos/IParseTemplateDTO';
+
+export default interface IMailTemplateProvider {
+
+  parse(data: IParseTemplateDTO): Promise<string>
+
+}

--- a/backend/src/shared/providers/index.ts
+++ b/backend/src/shared/providers/index.ts
@@ -1,5 +1,6 @@
 export const DI_STORAGE_PROVIDER = 'DI_STORAGE_PROVIDER'
 export const DI_MAIL_PROVIDER = 'DI_MAIL_PROVIDER'
+export const DI_MAIL_TEMPLATE_PROVIDER = 'DI_MAIL_TEMPLATE_PROVIDER'
 
 import { container as dependencyInjector } from 'tsyringe'
 
@@ -9,11 +10,18 @@ import DiskStorageProvider from './StorageProvider/implementations/DiskStoragePr
 import IMailProvider from './MailProvider/models/IMailProvider'
 import EtherealMailProvider from './MailProvider/implementations/EtherealMailProvider'
 
+import IMailTemplateProvider from './MailTemplateProvider/models/IMailTemplateProvider'
+import HandlebarsMailTemplateProvider from './MailTemplateProvider/implementations/HandlebarsMailTemplateProvider'
+
 
 dependencyInjector.registerSingleton<IStorageProvider> (
   DI_STORAGE_PROVIDER, DiskStorageProvider
 )
 
+dependencyInjector.registerSingleton<IMailTemplateProvider> (
+  DI_MAIL_TEMPLATE_PROVIDER, HandlebarsMailTemplateProvider
+)
+
 dependencyInjector.registerInstance<IMailProvider> (
-  DI_MAIL_PROVIDER, new EtherealMailProvider()
+  DI_MAIL_PROVIDER, dependencyInjector.resolve(EtherealMailProvider)
 )

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -600,6 +600,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/handlebars@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@types/handlebars/-/handlebars-4.1.0.tgz#3fcce9bf88f85fe73dc932240ab3fb682c624850"
+  integrity sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA==
+  dependencies:
+    handlebars "*"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"
@@ -2495,6 +2502,18 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
+handlebars@*, handlebars@^4.7.6:
+  version "4.7.6"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.6.tgz#d4c05c1baf90e9945f77aa68a7a219aa4a7df74e"
+  integrity sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==
+  dependencies:
+    minimist "^1.2.5"
+    neo-async "^2.6.0"
+    source-map "^0.6.1"
+    wordwrap "^1.0.0"
+  optionalDependencies:
+    uglify-js "^3.1.4"
+
 har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
@@ -3901,6 +3920,11 @@ negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
+
+neo-async@^2.6.0:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
+  integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
 nice-try@^1.0.4:
   version "1.0.5"
@@ -5446,6 +5470,11 @@ typescript@^4.1.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
   integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
 
+uglify-js@^3.1.4:
+  version "3.12.5"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.12.5.tgz#83241496087c640efe9dfc934832e71725aba008"
+  integrity sha512-SgpgScL4T7Hj/w/GexjnBHi3Ien9WS1Rpfg5y91WXMj9SY997ZCQU76mH4TpLwwfmMvoOU8wiaRkIf6NaH3mtg==
+
 union-value@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.1.tgz#0b6fe7b835aecda61c6ea4d4f02c14221e109847"
@@ -5617,6 +5646,11 @@ word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
+
+wordwrap@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+  integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
 wrap-ansi@^6.2.0:
   version "6.2.0"


### PR DESCRIPTION
yarn add handlebars

Existem vários templates de e-mail e para facilitar uma possível futura alteração
foi criado um provider também, o MailTemplateProvider.
Exitem várias node template engines, a utilizada foi o https://handlebarsjs.com/
handlebars é um template html simples com concateção de variáveis double mustache

EtherealMailProvider recebe injeção de dependência de DI_MAIL_TEMPLATE_PROVIDER