### PR TITLE
Appointments creation rules

### DIFF
--- a/backend/src/modules/appointments/services/CreateAppointmentService.ts
+++ b/backend/src/modules/appointments/services/CreateAppointmentService.ts
@@ -1,4 +1,4 @@
-import { startOfHour } from 'date-fns'
+import { startOfHour, isBefore, getHours } from 'date-fns'
 import { injectable, inject } from 'tsyringe'
 
 import { DI_APPOINTMENTS_REPOSITORY } from '@/shared/DependencyInjectionContainer'
@@ -6,6 +6,7 @@ import IAppointmentsRepository from '@/modules/appointments/repositories/IAppoin
 import ICreateAppointmentDTO from '@/modules/appointments/dtos/ICreateAppointmentDTO'
 import Appointment from '@/modules/appointments/infra/typeorm/entities/Appointment'
 import AppError from '@/shared/errors/AppError'
+import { LessThanOrEqual } from 'typeorm'
 
 @injectable()
 export default class CreateAppointmentService {
@@ -18,6 +19,19 @@ export default class CreateAppointmentService {
   public async execute({ provider_id, client_id, date }: ICreateAppointmentDTO): Promise<Appointment> {
 
     const appointmentDate = startOfHour(date)
+
+    if (isBefore(appointmentDate, Date.now())) {
+      throw new AppError("You can't create an appointment on a past date.")
+    }
+
+    if (client_id === provider_id) {
+      throw new AppError("You can't create an appointment with yourself.")
+    }
+
+    console.log('getHours(appointmentDate)', getHours(appointmentDate))
+    if (getHours(appointmentDate) < 8 || getHours(appointmentDate) > 17) {
+      throw new AppError('You can only create an appointment between 8am and 5pm')
+    }
 
     const findAppointmentInSameDate = await this.appointmentsRepository.findByDate(appointmentDate)
 

--- a/backend/src/modules/appointments/services/ListProviderDayAvailabilityService.spec.ts
+++ b/backend/src/modules/appointments/services/ListProviderDayAvailabilityService.spec.ts
@@ -13,23 +13,22 @@ describe('ListProviderDayAvailabilityService', () => {
     listProviderDayAvailabilityService = new ListProviderDayAvailabilityService(
       fakeAppointmentsRepository
     )
+
+    // Altera o funcionamento padrão do método Date retorando 2021/jan/1 11:00:00
+    jest.spyOn(Date, 'now').mockImplementationOnce(() => {
+      return new Date(2021, 0, 1, 11).getTime()
+    })
   })
 
 
   it('should be able to list the day availability from provider', async () => {
-
-    // Altera o funcionamento padrão do método Date retorando 2021/jan/31 11:00:00
-    jest.spyOn(Date, 'now').mockImplementationOnce(() => (
-      new Date(2021, 0, 31, 11).getTime()
-    ))
-
     const hours = [8, 11, 14, 15]
 
     hours.map(async hour => (
       await fakeAppointmentsRepository.create({
         provider_id: 'provider',
         client_id: 'client',
-        date: new Date(2021, 0, 31, hour, 0, 0) // 2021/jan/31
+        date: new Date(2021, 0, 1, hour, 0, 0)
       })
     ))
 
@@ -37,7 +36,7 @@ describe('ListProviderDayAvailabilityService', () => {
       provider_id: 'provider',
       year: 2021,
       month: 1, // jan
-      day: 31
+      day: 1
     })
 
     expect(availability).toEqual(availability)


### PR DESCRIPTION
Aplicado regras evitando por exemplo que um usuário faça um agendamento com ele mesmo ou em datas passadas, além de disponibilizar apenas horários válidos para a aplicação (das 8h às 18h).