### PR TITLE
Amazon SES mail provider

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -11,6 +11,7 @@
     "t": "jest"
   },
   "dependencies": {
+    "aws-sdk": "^2.841.0",
     "bcryptjs": "^2.4.3",
     "celebrate": "^13.0.4",
     "date-fns": "^2.16.1",

--- a/backend/src/config/mail.ts
+++ b/backend/src/config/mail.ts
@@ -1,0 +1,21 @@
+interface IMailConfig {
+  driver: 'ethereal' | 'ses'
+
+  defaults: {
+    from: {
+      email: string
+      name: string
+    }
+  }
+}
+
+export default {
+  driver: process.env.MAIL_DRIVER || 'ethereal',
+
+  defaults: {
+    from: {
+      email: 'no-reply@bordignon.dev',
+      name: 'Informações - Bordignon Dev'
+    }
+  }
+} as IMailConfig

--- a/backend/src/shared/providers/MailProvider/implementations/SESMailProvider.ts
+++ b/backend/src/shared/providers/MailProvider/implementations/SESMailProvider.ts
@@ -1,0 +1,45 @@
+import nodemailer, { Transporter } from 'nodemailer'
+import { injectable, inject } from 'tsyringe'
+import aws from 'aws-sdk'
+
+import mailConfig from '@/config/mail'
+import { DI_MAIL_TEMPLATE_PROVIDER } from '@/shared/providers'
+import IMailTemplateProvider from '@/shared/providers/MailTemplateProvider/models/IMailTemplateProvider'
+import IMailProvider from '../models/IMailProvider'
+import ISendMailDTO from '../dtos/ISendMailDTO'
+
+@injectable()
+export default class SESMailProvider implements IMailProvider {
+
+  private client: Transporter
+
+  constructor(
+    @inject(DI_MAIL_TEMPLATE_PROVIDER)
+    private mailTemplateProvider: IMailTemplateProvider
+  ) {
+
+    this.client = nodemailer.createTransport({
+      SES: new aws.SES({ apiVersion: '2010-12-01', region: 'us-east-1' })
+    })
+
+  }
+
+
+  public async sendMail({ to, from, subject, templateData }: ISendMailDTO): Promise<void> {
+    const { name, email } = mailConfig.defaults.from
+
+    await this.client.sendMail({
+      from:{
+        name: from ? from.name : name,
+        address: from ? from.email : email
+      },
+      to: {
+        name: to.name,
+        address: to.email
+      },
+      subject,
+      html: await this.mailTemplateProvider.parse(templateData)
+    })
+  }
+
+}

--- a/backend/src/shared/providers/index.ts
+++ b/backend/src/shared/providers/index.ts
@@ -4,11 +4,14 @@ export const DI_MAIL_TEMPLATE_PROVIDER = 'DI_MAIL_TEMPLATE_PROVIDER'
 
 import { container as dependencyInjector } from 'tsyringe'
 
+import mailConfig from '@/config/mail'
+
 import IStorageProvider from './StorageProvider/models/IStorageProvider'
 import DiskStorageProvider from './StorageProvider/implementations/DiskStorageProvider'
 
 import IMailProvider from './MailProvider/models/IMailProvider'
 import EtherealMailProvider from './MailProvider/implementations/EtherealMailProvider'
+import SESMailProvider from './MailProvider/implementations/SESMailProvider'
 
 import IMailTemplateProvider from './MailTemplateProvider/models/IMailTemplateProvider'
 import HandlebarsMailTemplateProvider from './MailTemplateProvider/implementations/HandlebarsMailTemplateProvider'
@@ -23,5 +26,8 @@ dependencyInjector.registerSingleton<IMailTemplateProvider> (
 )
 
 dependencyInjector.registerInstance<IMailProvider> (
-  DI_MAIL_PROVIDER, dependencyInjector.resolve(EtherealMailProvider)
+  DI_MAIL_PROVIDER,
+  mailConfig.driver === 'ethereal'
+    ? dependencyInjector.resolve(EtherealMailProvider)
+    : dependencyInjector.resolve(SESMailProvider)
 )

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -1089,6 +1089,21 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
+aws-sdk@^2.841.0:
+  version "2.841.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.841.0.tgz#a29314f6696bdf02a4c952b6f7c791042fa61eaa"
+  integrity sha512-pMgFr0B4WFIZEKc6EPAcyrvafkqoE1JwU6DJuE4UmT2ntat87DnbWUzFRP2HB4HuJvP1F7KNmElMz8p8j8bkNg==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
@@ -1165,7 +1180,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base64-js@^1.3.1:
+base64-js@^1.0.2, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -1293,6 +1308,15 @@ buffer-from@1.x, buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
+buffer@4.9.2:
+  version "4.9.2"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
+  integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+    isarray "^1.0.0"
 
 buffer@^5.5.0:
   version "5.7.1"
@@ -2149,6 +2173,11 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
+events@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
+
 exec-sh@^0.3.2:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.4.tgz#3a018ceb526cc6f6df2bb504b2bfe8e3a4934ec5"
@@ -2735,7 +2764,12 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-ieee754@^1.1.13:
+ieee754@1.1.13:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
+  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
+
+ieee754@^1.1.13, ieee754@^1.1.4:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -3462,6 +3496,11 @@ jest@^26.6.3:
     "@jest/core" "^26.6.3"
     import-local "^3.0.2"
     jest-cli "^26.6.3"
+
+jmespath@0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
+  integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
 
 joi@17.x.x:
   version "17.3.0"
@@ -4510,6 +4549,11 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
+punycode@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
+
 punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
@@ -4524,6 +4568,11 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+querystring@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 range-parser@~1.2.1:
   version "1.2.1"
@@ -4853,6 +4902,11 @@ saslprep@^1.0.0:
   integrity sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==
   dependencies:
     sparse-bitfield "^3.0.3"
+
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
 
 sax@>=0.6.0:
   version "1.2.4"
@@ -5649,6 +5703,14 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
+url@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
+  integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
@@ -5663,6 +5725,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
+
+uuid@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
 uuid@^3.3.2:
   version "3.4.0"
@@ -5834,6 +5901,14 @@ xml-name-validator@^3.0.0:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
+xml2js@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~9.0.1"
+
 xml2js@^0.4.23:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
@@ -5846,6 +5921,11 @@ xmlbuilder@~11.0.0:
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
   integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
+
+xmlbuilder@~9.0.1:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
 
 xmlchars@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
1. Necessário ter um domínio próprio
   1.1. Comprei um domínio no google domains
   1.2. Criei uma conta no Zoho
   1.3. Conectei o Zoho com o domínio no google, os códigos gerados pelo Zoho são
   inserido no google domains na aba  DNS -> Registros de recursos personalizados

- Verificação TXT -> Nome: @, Tipo: TXT, TTL: 60, Dados: "zoho-verification=xxx"
- mx.zoho.com. -> Nome: @, Tipo: MX, TTL: 100, Dados: em dados tem q registrar as
  três configurações, a primeira é
  10 mx.zoho.com.
  clicando em + para add as outras duas
  20 mx2.zoho.com.
  50 mx3.zoho.com.

Demorou bastante tempo pra funcionar, pensei q havia feito algo errado e abandonei,
no outro dia apenas atualizei a tela do Zoho e pronto, tudo funcionando.

2. No console aws console.aws.amazon.com
   2.1 CLicar em "All Services" -> "Simple Email Service" (É possível que a conta ainda não esteja verificada )
   Depois clicar em Domains -> Verify a New Domain (Inserir o domínio e Verificar)
   O box que abrir vai ter o "Domain Verification Record", esse é o usado para enviar e-mails
   o "Email Receiving Record" é usado caso for receber e-mails também.
   O registro desse token é igual aos feitos anteriormente, na aba "Registros de recursos personalizados" no google domains

   seguindo a doc https://nodemailer.com/transports/ses/ foi configurado o SESMailProvider

   após isso é necessário criar uma chave de acesso na aws, Identity and Access Management (IAM)
   https://console.aws.amazon.com/iam/home?region=us-east-1#/users

   1. setar um nome e selecionar 'Programmatic access'
   2. Attach existing policies directly -> AmazonSESFullAccess -> next,next,create

   copiar chave e senha, guardar pois não é possível recuperar, inserir elas no .env com nas seguintes constantes.
   
AWS_ACCESS_KEY_ID=
AWS_SECRET_ACCESS_KEY=

pra testar enviar um e-mail para um endereço verificado no AmazonSES pois não envia e-mails para qualquer endereço em modo de teste.