### PR TITLE
Providers list Cache

### DIFF
--- a/backend/src/modules/appointments/services/ListProvidersService.ts
+++ b/backend/src/modules/appointments/services/ListProvidersService.ts
@@ -1,9 +1,11 @@
 import { injectable, inject } from 'tsyringe'
 
-import User from '@/modules/users/infra/typeorm/entities/User'
-
 import { DI_USERS_REPOSITORY } from '@/shared/DependencyInjectionContainer'
 import IUsersRepository from '@/modules/users/repositories/IUsersRepository'
+import { DI_CACHE_PROVIDER } from '@/shared/providers/CacheProvider'
+import ICacheProvider from '@/shared/providers/CacheProvider/models/ICacheProvider'
+
+import User from '@/modules/users/infra/typeorm/entities/User'
 
 interface IRequest {
   user_id: string
@@ -14,13 +16,23 @@ export default class ListProvidersService {
 
   constructor(
     @inject(DI_USERS_REPOSITORY)
-    private usersRepository: IUsersRepository
+    private usersRepository: IUsersRepository,
+
+    @inject(DI_CACHE_PROVIDER)
+    private cacheProvider: ICacheProvider
   ) {}
 
   public async execute({ user_id }: IRequest): Promise<User[]> {
-    const users = await this.usersRepository.findAllProviders({
-      except_user_id: user_id
-    })
+
+    let users = await this.cacheProvider.get<User[]>(`providers-list:${user_id}`)
+
+    if (!users) {
+      users = await this.usersRepository.findAllProviders({
+        except_user_id: user_id
+      })
+
+      await this.cacheProvider.set(`providers-list:${user_id}`, users)
+    }
 
     return users
   }

--- a/backend/src/modules/users/services/CreateUserService.ts
+++ b/backend/src/modules/users/services/CreateUserService.ts
@@ -1,11 +1,15 @@
 import { injectable, inject } from 'tsyringe'
 
-import { DI_USERS_REPOSITORY } from '@/shared/DependencyInjectionContainer'
-import { DI_HASH_PROVIDER } from '../providers'
 import AppError from '@/shared/errors/AppError'
-import ICreateUserDTO from '@/modules/users/dtos/ICreateUserDTO'
+
+import { DI_USERS_REPOSITORY } from '@/shared/DependencyInjectionContainer'
 import IUsersRepository from '@/modules/users/repositories/IUsersRepository'
+import { DI_HASH_PROVIDER } from '../providers'
 import IHashProvider from '@/modules/users/providers/HashProvider/models/IHashProvider'
+import { DI_CACHE_PROVIDER } from '@/shared/providers/CacheProvider'
+import ICacheProvider from '@/shared/providers/CacheProvider/models/ICacheProvider'
+
+import ICreateUserDTO from '@/modules/users/dtos/ICreateUserDTO'
 import User from '@/modules/users/infra/typeorm/entities/User'
 
 @injectable()
@@ -16,7 +20,10 @@ export default class CreateUserService {
     private usersRepository: IUsersRepository,
 
     @inject(DI_HASH_PROVIDER)
-    private hashProvider: IHashProvider
+    private hashProvider: IHashProvider,
+
+    @inject(DI_CACHE_PROVIDER)
+    private cacheProvider: ICacheProvider
   ) {}
 
   public async execute({ name, email, password }: ICreateUserDTO): Promise<User> {
@@ -32,6 +39,8 @@ export default class CreateUserService {
     const user = await this.usersRepository.create({
       name, email, password: hashPassword
     })
+
+    await this.cacheProvider.removePrefix('providers-list')
 
     return user
   }

--- a/backend/src/shared/providers/CacheProvider/implementations/RedisCacheProvider.ts
+++ b/backend/src/shared/providers/CacheProvider/implementations/RedisCacheProvider.ts
@@ -15,13 +15,30 @@ export default class RedisCacheProvider implements ICacheProvider {
     await this.redis.set(key, JSON.stringify(value))
   }
 
-  public async get(key: string): Promise<any> {
+  public async get<T>(key: string): Promise<T | null> {
     const data = await this.redis.get(key)
-    return data
+
+    if (!data) return null
+
+    const parseData = JSON.parse(data) as T
+
+    return parseData
   }
 
-  public async invalidate(key: string): Promise<void> {
 
+  public async remove(key: string): Promise<void> {
+
+  }
+
+
+  public async removePrefix(prefix: string): Promise<void> {
+    const keys = await this.redis.keys(`${prefix}:*`)
+
+    const pipeline = this.redis.pipeline()
+
+    keys.forEach(key => pipeline.del(key))
+
+    await pipeline.exec()
   }
 
 }

--- a/backend/src/shared/providers/CacheProvider/models/ICacheProvider.ts
+++ b/backend/src/shared/providers/CacheProvider/models/ICacheProvider.ts
@@ -1,7 +1,8 @@
 export default interface ICacheProvider {
 
   set(key: string, value:any): Promise<void>
-  get(key: string): Promise<any>
-  invalidate(key: string): Promise<void>
+  get<T>(key: string): Promise<T | null>
+  remove(key: string): Promise<void>
+  removePrefix(prefix: string): Promise<void>
 
 }


### PR DESCRIPTION
Ao listar os providers, primeiro procura se existe uma lista em cache, caso tenha, retorna a lista, caso não, busca do mysql e salva em cache para a próxima consulta .

Ao registrar um novo provider, remove do cache a lista de providers para que seja gerada na próxima consulta